### PR TITLE
Fix release pid RPC tests

### DIFF
--- a/1.9/Dockerfile
+++ b/1.9/Dockerfile
@@ -53,6 +53,10 @@ RUN set -x \
   && cd .. \
   && rm -rf otp_src_${ERLANG_VERSION}
 
+# Copy Elixir patch
+COPY patch/elixir/fix-release-test.patch \
+     patch/fix-release-test.patch
+
 # Install Elixir
 RUN set -x \
   && localedef -i en_US -f UTF-8 en_US.UTF-8 \
@@ -66,9 +70,11 @@ RUN set -x \
   make \
   ncurses-devel \
   openssl-devel \
+  patch \
   wxBase \
   && git clone -b v${ELIXIR_VERSION} https://github.com/elixir-lang/elixir.git \
   && cd elixir \
+  && patch -p0 < ../patch/fix-release-test.patch \
   && export LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 \
   && make clean \
   && make test \
@@ -80,10 +86,12 @@ RUN set -x \
   java-1.8.0-openjdk-devel \
   ncurses-devel \
   openssl-devel \
+  patch \
   wxBase \
   && yum clean all -y \
   && cd .. \
-  && rm -rf elixir
+  && rm -rf elixir \
+  && rm -rf patch
 
 # Install node/npm
 RUN set -x \

--- a/1.9/patch/elixir/fix-release-test.patch
+++ b/1.9/patch/elixir/fix-release-test.patch
@@ -1,0 +1,15 @@
+--- lib/mix/test/mix/tasks/release_test.exs
++++ lib/mix/test/mix/tasks/release_test.exs
+
+@@ -281,10 +281,9 @@ defmodule Mix.Tasks.ReleaseTest do
+         open_port(script, ['start'])
+         wait_until_decoded(Path.join(root, "RELEASE_BOOTED"))
+         assert System.cmd(script, ["rpc", "ReleaseTest.hello_world"]) == {"hello world\n", 0}
+-        assert System.cmd(script, ["stop"]) == {"", 0}
+-
+         assert {pid, 0} = System.cmd(script, ["pid"])
+         assert pid != "\n"
++        assert System.cmd(script, ["stop"]) == {"", 0}
+       end)
+     end)
+   end


### PR DESCRIPTION
A patch has been included which should fix the release RPC tests.

Please test these changes first, I might have missed something when I wrote the Dockerfile. A similar setup works for my own Dockerfiles, though.